### PR TITLE
タイムゾーンを東京に変更

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,7 @@ module AwesomeEvents
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
+    config.time_zone = 'Tokyo'
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]


### PR DESCRIPTION
### PRの目的

システムが使用されるのが日本である前提があるので、タイムゾーンを東京に変更しました。
### 動作確認

コンソールで下記を実行して、 `Tokyo` が出力されることを確認

``` ruby
Rails.application.config.time_zone  # => "Tokyo"
```
