### PR TITLE
ログイン状態を管理する機能の実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,11 @@ class ApplicationController < ActionController::Base
 
   private
 
+  def authenticate
+    return if logged_in?
+    redirect_to root_path
+  end
+
   def logged_in?
     !!session[:user_id]
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
 
   def authenticate
     return if logged_in?
-    redirect_to root_path
+    redirect_to root_path, alert: 'ログインしてください。'
   end
 
   def logged_in?

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,6 +37,11 @@
         <%= flash[:notice] %>
       </div>
     <% end %>
+    <% if flash[:alert] %>
+      <div class="alert alert-danger">
+        <%= flash[:alert] %>
+      </div>
+    <% end %>
     <%= yield %>
   </div>
 </body>

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationController, type: :controller do
+  controller do
+    before_action :authenticate
+
+    def index
+      render text: "This is test page."
+    end
+  end
+
+  context 'ログインしている状態のとき' do
+    before do
+      session[:user_id] = 1
+      get :index
+    end
+
+    it 'コントローラのアクションが呼ばれること' do
+      expect(response.body).to have_text 'This is test page.'
+    end
+  end
+
+  context 'ログインしていない状態のとき' do
+    before { get :index }
+
+    it 'トップページにリダイレクトされること' do
+      expect(response).to redirect_to root_path
+    end
+  end
+end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -26,5 +26,9 @@ RSpec.describe ApplicationController, type: :controller do
     it 'トップページにリダイレクトされること' do
       expect(response).to redirect_to root_path
     end
+
+    it 'flashに格納されるメッセージが"ログインしていません"であること' do
+      expect(flash[:alert]).to eq 'ログインしてください。'
+    end
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe ApplicationController, type: :controller do
       expect(response).to redirect_to root_path
     end
 
-    it 'flashに格納されるメッセージが"ログインしていません"であること' do
+    it 'flashに格納されるメッセージが "ログインしてください。" であること' do
       expect(flash[:alert]).to eq 'ログインしてください。'
     end
   end


### PR DESCRIPTION
### PRで実現すること

ログイン周りの共通処理をApplicationControllerに実装し、どのコントローラが呼ばれても共通の処理が走るようにします。
### 変更内容または TODO
- [x] 未ログイン時にトップページにリダイレクトさせる
  - [x] ApplicationControllerのテストを記述 
  - [x] ログインしていない場合、レイアウトに「ログインしていません。」と表示させる 
- [ ] ~~ログインしているユーザを取得するメソッドを実装~~
  
  「ログインしているユーザを取得するメソッドを実装」に関しては、必要になったタイミングで実装する、という方向で考えています。
### 動作確認

下記を実行したところ、

```
be rspec spec/controllers/application_controller_spec.rb
```

次の結果になりました。

```
ApplicationController
  ログインしている状態のとき
    コントローラのアクションが呼ばれること
  ログインしていない状態のとき
    トップページにリダイレクトされること
    flashに格納されるメッセージが"ログインしていません"であること

Finished in 0.03569 seconds (files took 2.9 seconds to load)
3 examples, 0 failures
```
