### PR TITLE
イベント登録フォームの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ group :development, :test do
 
   # Test framework
   gem 'rspec-rails'
-
+  gem 'factory_girl_rails'
   gem 'shoulda-matchers'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,11 @@ GEM
     diff-lcs (1.2.5)
     erubis (2.7.0)
     execjs (2.7.0)
+    factory_girl (4.7.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.7.0)
+      factory_girl (~> 4.7.0)
+      railties (>= 3.0.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     hashie (3.4.4)
@@ -206,6 +211,7 @@ DEPENDENCIES
   byebug
   capybara
   coffee-rails (~> 4.1.0)
+  factory_girl_rails
   jbuilder (~> 2.0)
   jquery-rails
   omniauth
@@ -227,4 +233,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.12.3
+   1.12.5

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,2 +1,4 @@
 class EventsController < ApplicationController
+  def new
+  end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,4 +1,5 @@
 class EventsController < ApplicationController
   def new
+    @event = User.find(session[:user_id]).created_events.build
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -7,7 +7,13 @@ class EventsController < ApplicationController
   end
 
   def create
-    @event = User.find(session[:user_id]).created_events.build
+    @event = User.find(session[:user_id]).created_events.build(event_params)
     redirect_to @event
+  end
+
+  private
+
+  def event_params
+    params.require(:event).permit(:name, :place, :start_time, :end_time, :content)
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,5 +1,13 @@
 class EventsController < ApplicationController
+  def show
+  end
+
   def new
     @event = User.find(session[:user_id]).created_events.build
+  end
+
+  def create
+    @event = User.find(session[:user_id]).created_events.build
+    redirect_to @event
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -9,7 +9,7 @@ class EventsController < ApplicationController
   def create
     @event = User.find(session[:user_id]).created_events.build(event_params)
     @event.save
-    redirect_to @event
+    redirect_to @event, notice: '作成しました。'
   end
 
   private

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -8,6 +8,7 @@ class EventsController < ApplicationController
 
   def create
     @event = User.find(session[:user_id]).created_events.build(event_params)
+    @event.save
     redirect_to @event
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -8,8 +8,12 @@ class EventsController < ApplicationController
 
   def create
     @event = User.find(session[:user_id]).created_events.build(event_params)
-    @event.save
-    redirect_to @event, notice: '作成しました。'
+
+    if @event.save
+      redirect_to @event, notice: '作成しました。'
+    else
+      render :new
+    end
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ActiveRecord::Base
+  has_many :created_events, class_name: 'Event', foreign_key: :owner_id
+
   def self.find_or_create_from_auth_hash(auth_hash)
     provider  = auth_hash[:provider]
     uid       = auth_hash[:uid]

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,0 +1,47 @@
+<% now = Time.zone.now %>
+
+<div class="page-header">
+  <h1>イベント作成</h1>
+</div>
+
+<%= form_for(@event, class: 'form-horizontal', role: 'form') do |f| %>
+  <% if @event.errors.any? %>
+    <div class="alert alert-danger">
+      <ul>
+      <% @event.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="form-group">
+    <%= f.label :name %>
+    <%= f.text_field :name, class: 'form-control' %>
+  <div>
+
+  <div class="form-group">
+    <%= f.label :place %>
+    <%= f.text_field :name, class: 'form-control' %>
+  <div>
+
+  <div class="form-group">
+    <%= f.label :start_time %>
+    <div>
+      <%= f.datetime_select :start_time, start_year: now.year, end_year: now.year + 1 %>
+    </div>
+  <div>
+
+  <div class="form-group">
+    <%= f.label :end_time %>
+    <div>
+      <%= f.datetime_select :end_time, start_year: now.year, end_year: now.year + 1 %>
+    </div>
+  <div>
+
+  <div class="form-group">
+    <%= f.label :content %>
+    <%= f.text_field :content, class: 'form-control', row: 10 %>
+  <div>
+  <%= f.submit '作成', class: 'btn btn-default', data: { disable_with: '作成中…' } %>
+<% end %>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -22,7 +22,7 @@
 
   <div class="form-group">
     <%= f.label :place %>
-    <%= f.text_field :name, class: 'form-control' %>
+    <%= f.text_field :place, class: 'form-control' %>
   <div>
 
   <div class="form-group">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,6 +22,7 @@
       </div>
       <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
         <ul class="nav navbar-nav navbar-right">
+          <li><%= link_to 'イベントを作る', new_event_path %></li>
           <% if logged_in? %>
             <li><%= link_to 'ログアウト', logout_path %></li>
           <% else %>

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -3,6 +3,13 @@ require 'rails_helper'
 RSpec.describe EventsController, type: :controller do
   describe 'GET /events/new' do
     before do
+      user = User.create(
+        provider: 'twitter',
+        uid: '12345',
+        nickname: 'nickname_test',
+        image_url: 'image.jpg'
+      )
+      session[:user_id] = user.id
       get :new
     end
 
@@ -14,6 +21,8 @@ RSpec.describe EventsController, type: :controller do
       expect(response).to render_template 'new'
     end
 
-    it '@event に空イベントが格納されていること'
+    it '@event に空イベントが格納されていること' do
+      expect(controller.instance_variable_get("@event")).to be_a_new(Event)
+    end
   end
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -62,10 +62,22 @@ RSpec.describe EventsController, type: :controller do
     end
 
     context '登録失敗するとき' do
-      it 'ステータスコードが200であること'
+      before do
+        @params[:event][:start_time] = 'valid_err'
+        post :create, @params
+      end
 
-      it 'ビューとして new.html.erb が呼ばれること'
+      it 'ステータスコードが200であること' do
+        expect(response.status).to eq 200
+      end
 
+      it 'ビューとして new.html.erb が呼ばれること' do
+        expect(response).to render_template(:new)
+      end
+
+      it '@eventにエラー情報が格納されていること' do
+        expect(controller.instance_variable_get("@event").errors.any?).to be_truthy
+      end
     end
   end
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -51,7 +51,10 @@ RSpec.describe EventsController, type: :controller do
         expect(response).to redirect_to controller.instance_variable_get("@event")
       end
 
-      it 'フォーム送信されたデータと、DBに登録されたデータが一致すること'
+      it 'フォーム送信されたデータと、DBに登録されたデータが一致すること' do
+        columns = @params[:event].keys
+        expect(controller.instance_variable_get("@event").attributes.symbolize_keys.slice(*columns)).to eq @params[:event]
+      end
 
       it 'flash[:notice] に 作成しました という文字列が格納されていること'
     end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -2,12 +2,7 @@ require 'rails_helper'
 
 RSpec.describe EventsController, type: :controller do
   before do
-    @user = User.create(
-      provider: 'twitter',
-      uid: '12345',
-      nickname: 'nickname_test',
-      image_url: 'image.jpg'
-    )
+    @user = FactoryGirl.create(:user)
     session[:user_id] = @user.id
   end
 
@@ -31,20 +26,9 @@ RSpec.describe EventsController, type: :controller do
   end
 
   describe 'POST /events/' do
-    before do
-      @params = {
-        event: {
-          name:       'test.name',
-          place:      'test.place',
-          start_time: Time.local(2015, 1),
-          end_time:   Time.local(2016, 1),
-          content:    'test.content'
-        }
-      }
-    end
-
     context '登録成功するとき' do
       before do
+        @params = { event: FactoryGirl.attributes_for(:event) }
         post :create, @params
       end
 
@@ -64,7 +48,7 @@ RSpec.describe EventsController, type: :controller do
 
     context '登録失敗するとき' do
       before do
-        @params[:event][:start_time] = 'valid_err'
+        @params = { event: FactoryGirl.attributes_for(:event, :with_blank) }
         post :create, @params
       end
 

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -56,7 +56,9 @@ RSpec.describe EventsController, type: :controller do
         expect(controller.instance_variable_get("@event").attributes.symbolize_keys.slice(*columns)).to eq @params[:event]
       end
 
-      it 'flash[:notice] に 作成しました という文字列が格納されていること'
+      it 'flash[:notice] に「作成しました。」という文字列が格納されていること' do
+        expect(flash[:notice]).to eq '作成しました。'
+      end
     end
 
     context '登録失敗するとき' do

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -2,13 +2,13 @@ require 'rails_helper'
 
 RSpec.describe EventsController, type: :controller do
   before do
-    user = User.create(
+    @user = User.create(
       provider: 'twitter',
       uid: '12345',
       nickname: 'nickname_test',
       image_url: 'image.jpg'
     )
-    session[:user_id] = user.id
+    session[:user_id] = @user.id
   end
 
   describe 'GET /events/new' do
@@ -31,12 +31,20 @@ RSpec.describe EventsController, type: :controller do
 
   describe 'POST /events/' do
     before do
-      post :create
+      @params = {
+        event: {
+          name:       'test.name',
+          place:      'test.place',
+          start_time: Time.local(2015, 1),
+          end_time:   Time.local(2016, 1),
+          content:    'test.content'
+        }
+      }
     end
 
     context '登録成功するとき' do
-      it 'ステータスコードが302であること' do
-        expect(response.status).to eq 302
+      before do
+        post :create, @params
       end
 
       it '/event/:作成したイベントID にリダイレクトされること' do
@@ -53,9 +61,6 @@ RSpec.describe EventsController, type: :controller do
 
       it 'ビューとして new.html.erb が呼ばれること'
 
-      context '指定されていないパラメータを受け取ったとき' do
-        it 'ActionController::UnpermittedParametersの例外が発生すること'
-      end
     end
   end
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -1,5 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe EventsController, type: :controller do
+  describe 'GET /events/new' do
+    before { get :new }
 
+    it 'ステータスコードが200であること'
+
+    it 'ビューとして new.html.erb が呼ばれること'
+
+    it '@event に空イベントが格納されていること'
+  end
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe EventsController, type: :controller do
   before do
-    @user = FactoryGirl.create(:user)
+    @user = create(:user)
     session[:user_id] = @user.id
   end
 
@@ -28,7 +28,7 @@ RSpec.describe EventsController, type: :controller do
   describe 'POST /events/' do
     context '登録成功するとき' do
       before do
-        @params = { event: FactoryGirl.attributes_for(:event) }
+        @params = { event: attributes_for(:event) }
         post :create, @params
       end
 
@@ -48,7 +48,7 @@ RSpec.describe EventsController, type: :controller do
 
     context '登録失敗するとき' do
       before do
-        @params = { event: FactoryGirl.attributes_for(:event, :with_blank) }
+        @params = { event: attributes_for(:event, :with_blank) }
         post :create, @params
       end
 

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -24,8 +24,9 @@ RSpec.describe EventsController, type: :controller do
       expect(response).to render_template 'new'
     end
 
-    it '@event に空イベントが格納されていること' do
+    it '@event にセッションのユーザIDと紐付く空イベントが格納されていること' do
       expect(assigns(:event)).to be_a_new(Event)
+      expect(assigns(:event).owner_id).to eq @user.id
     end
   end
 

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -35,9 +35,13 @@ RSpec.describe EventsController, type: :controller do
     end
 
     context '登録成功するとき' do
-      it 'ステータスコードが200であること'
+      it 'ステータスコードが200であること' do
+        expect(response.status).to eq 200
+      end
 
-      it '/event/:作成したイベントID にリダイレクトされること'
+      it '/event/:作成したイベントID にリダイレクトされること' do
+        expect(response).to redirect_to controller.instance_variable_get("@event")
+      end
 
       it 'フォーム送信されたデータと、DBに登録されたデータが一致すること'
 

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -27,41 +27,45 @@ RSpec.describe EventsController, type: :controller do
 
   describe 'POST /events/' do
     context '登録成功するとき' do
-      before do
-        @params = { event: attributes_for(:event) }
-        post :create, @params
-      end
+      context 'フォームに全てのデータが入力されているとき' do
+        before do
+          @params = { event: attributes_for(:event) }
+          post :create, @params
+        end
 
-      it '/event/:作成したイベントID にリダイレクトされること' do
-        expect(response).to redirect_to assigns(:event)
-      end
+        it '/event/:作成したイベントID にリダイレクトされること' do
+          expect(response).to redirect_to assigns(:event)
+        end
 
-      it 'フォーム送信されたデータと、DBに登録されたデータが一致すること' do
-        columns = @params[:event].keys
-        expect(assigns(:event).attributes.symbolize_keys.slice(*columns)).to eq @params[:event]
-      end
+        it 'フォーム送信されたデータと、DBに登録されたデータが一致すること' do
+          columns = @params[:event].keys
+          expect(assigns(:event).attributes.symbolize_keys.slice(*columns)).to eq @params[:event]
+        end
 
-      it 'flash[:notice] に「作成しました。」という文字列が格納されていること' do
-        expect(flash[:notice]).to eq '作成しました。'
+        it 'flash[:notice] に「作成しました。」という文字列が格納されていること' do
+          expect(flash[:notice]).to eq '作成しました。'
+        end
       end
     end
 
     context '登録失敗するとき' do
-      before do
-        @params = { event: attributes_for(:event, :with_blank) }
-        post :create, @params
-      end
+      context 'フォームに入力されたデータが空のとき' do
+        before do
+          @params = { event: attributes_for(:event, :with_blank) }
+          post :create, @params
+        end
 
-      it 'ステータスコードが200であること' do
-        expect(response.status).to eq 200
-      end
+        it 'ステータスコードが200であること' do
+          expect(response.status).to eq 200
+        end
 
-      it 'ビューとして new.html.erb が呼ばれること' do
-        expect(response).to render_template(:new)
-      end
+        it 'ビューとして new.html.erb が呼ばれること' do
+          expect(response).to render_template(:new)
+        end
 
-      it '@eventにエラー情報が格納されていること' do
-        expect(assigns(:event).errors.any?).to be_truthy
+        it '@eventにエラー情報が格納されていること' do
+          expect(assigns(:event).errors.any?).to be_truthy
+        end
       end
     end
   end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe EventsController, type: :controller do
     end
 
     context '登録成功するとき' do
-      it 'ステータスコードが200であること' do
-        expect(response.status).to eq 200
+      it 'ステータスコードが302であること' do
+        expect(response.status).to eq 302
       end
 
       it '/event/:作成したイベントID にリダイレクトされること' do

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -25,4 +25,30 @@ RSpec.describe EventsController, type: :controller do
       expect(controller.instance_variable_get("@event")).to be_a_new(Event)
     end
   end
+
+  describe 'POST /events/' do
+    before do
+      get :new
+    end
+
+    context '登録成功するとき' do
+      it 'ステータスコードが200であること'
+
+      it '/event/:作成したイベントID にリダイレクトされること'
+
+      it 'フォーム送信されたデータと、DBに登録されたデータが一致すること'
+
+      it 'flash[:notice] に 作成しました という文字列が格納されていること'
+    end
+
+    context '登録失敗するとき' do
+      it 'ステータスコードが200であること'
+
+      it 'ビューとして new.html.erb が呼ばれること'
+
+      context '指定されていないパラメータを受け取ったとき' do
+        it 'ActionController::UnpermittedParametersの例外が発生すること'
+      end
+    end
+  end
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe EventsController, type: :controller do
     end
 
     it '@event に空イベントが格納されていること' do
-      expect(controller.instance_variable_get("@event")).to be_a_new(Event)
+      expect(assigns(:event)).to be_a_new(Event)
     end
   end
 
@@ -48,12 +48,12 @@ RSpec.describe EventsController, type: :controller do
       end
 
       it '/event/:作成したイベントID にリダイレクトされること' do
-        expect(response).to redirect_to controller.instance_variable_get("@event")
+        expect(response).to redirect_to assigns(:event)
       end
 
       it 'フォーム送信されたデータと、DBに登録されたデータが一致すること' do
         columns = @params[:event].keys
-        expect(controller.instance_variable_get("@event").attributes.symbolize_keys.slice(*columns)).to eq @params[:event]
+        expect(assigns(:event).attributes.symbolize_keys.slice(*columns)).to eq @params[:event]
       end
 
       it 'flash[:notice] に「作成しました。」という文字列が格納されていること' do
@@ -76,7 +76,7 @@ RSpec.describe EventsController, type: :controller do
       end
 
       it '@eventにエラー情報が格納されていること' do
-        expect(controller.instance_variable_get("@event").errors.any?).to be_truthy
+        expect(assigns(:event).errors.any?).to be_truthy
       end
     end
   end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -1,15 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe EventsController, type: :controller do
+  before do
+    user = User.create(
+      provider: 'twitter',
+      uid: '12345',
+      nickname: 'nickname_test',
+      image_url: 'image.jpg'
+    )
+    session[:user_id] = user.id
+  end
+
   describe 'GET /events/new' do
     before do
-      user = User.create(
-        provider: 'twitter',
-        uid: '12345',
-        nickname: 'nickname_test',
-        image_url: 'image.jpg'
-      )
-      session[:user_id] = user.id
       get :new
     end
 
@@ -28,7 +31,7 @@ RSpec.describe EventsController, type: :controller do
 
   describe 'POST /events/' do
     before do
-      get :new
+      post :create
     end
 
     context '登録成功するとき' do

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -2,11 +2,17 @@ require 'rails_helper'
 
 RSpec.describe EventsController, type: :controller do
   describe 'GET /events/new' do
-    before { get :new }
+    before do
+      get :new
+    end
 
-    it 'ステータスコードが200であること'
+    it 'ステータスコードが200であること' do
+      expect(response.status).to eq 200
+    end
 
-    it 'ビューとして new.html.erb が呼ばれること'
+    it 'ビューとして new.html.erb が呼ばれること' do
+      expect(response).to render_template 'new'
+    end
 
     it '@event に空イベントが格納されていること'
   end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :event do
+    
+  end
+end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,5 +1,17 @@
 FactoryGirl.define do
   factory :event do
-    
+    sequence(:name)    {|i| "#{i}" }
+    sequence(:place)   {|i| "nickname#{i}" }
+    start_time         Time.local(2015, 1)
+    end_time           Time.local(2016, 1)
+    sequence(:content) {|i| "nickname#{i}" }
+
+    trait :with_blank do
+      name       nil
+      place      nil
+      start_time nil
+      end_time   nil
+      content    nil
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :user do
+    
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,8 @@
 FactoryGirl.define do
   factory :user do
-    
+    provider             'twitter'
+    sequence(:uid)       {|i| "#{i}" }
+    sequence(:nickname)  {|i| "nickname#{i}" }
+    sequence(:image_url) {|i| "http://test.com/test#{i}.jpg" }
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -44,6 +44,10 @@ RSpec.configure do |config|
     })
   end
 
+  # FactoryGirlのメソッド呼び出しの際にクラス名を省略するための設定
+  config.include FactoryGirl::Syntax::Methods
+
+  # ActiveModelのテストにおいてShouldaMatchersが提供するマッチャを使用するための設定
   config.include Shoulda::Matchers::ActiveModel, type: :model
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures


### PR DESCRIPTION
### PRの目的

イベントの新規作成フォームを実装します。
### 背景

今までWIPでPRを上げずに作業していた内容が大きく間違っていたため、再度やり直します。
今回はきちんとWIPでPRを出し、作業ログを残しながら作業します。
### Todo
- [x] トップページにイベント新規作成画面へのリンクを追加する
- [x] Userモデルにhas_many関係としてEventモデルを設定
- [x] Eventコントローラの `new` アクションの実装  
  - [x] イベント新規作成へのルーティング `GET /event/new` に対するアクション `#new` のテストを書く
    - [x] ステータスコードが200であること
    - [x] ビューとして new.html.erb が呼ばれること
    - [x] `@event` に空イベントが格納されていること
  - [x] 各テスト項目に対して機能を実装する
- [x] Eventコントローラの `create` アクションの実装  
  - [x] イベント新規作成へのルーティング `POST /event/` に対するアクション `#create` のテストを書く
  - 登録成功時
    - [x] `/event/:作成したイベントID` にリダイレクトされること
    - [x] 登録したデータと、登録後取得できる値が等しいこと
    - [x] `flash[:notice]` に `作成しました` という文字列が格納されていること
  - 登録失敗時
    - [x] ステータスコードが200であること
    - [x] ビューとして new.html.erb が呼ばれること
    - [x] エラーが発生した際に、インスタンス変数にエラーが格納されていること
  - [x] 各テスト項目に対して機能を実装 
### テスト以外の確認項目
- [x] イベント登録後のshowテンプレートに「作成しました。」と表示されること。

<img width="1226" alt="2016-06-08 15 38 25" src="https://cloud.githubusercontent.com/assets/10118235/15885048/5619d250-2d8f-11e6-878a-49884efbce6c.png">
- [x] 登録失敗時に呼び出されるnewテンプレートにエラー内容が表示されていること

<img width="1209" alt="2016-06-08 15 37 52" src="https://cloud.githubusercontent.com/assets/10118235/15885045/53d4f6d2-2d8f-11e6-9f47-06058aacf796.png">
