### PR TITLE
イベント新規作成画面でユーザ認証が行われていなかったバグの修正

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,4 +1,6 @@
 class EventsController < ApplicationController
+  before_action :authenticate
+
   def show
   end
 

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'pry-rails'
 
 RSpec.describe EventsController, type: :controller do
   shared_examples_for 'authenticate' do

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -1,82 +1,96 @@
 require 'rails_helper'
+require 'pry-rails'
 
 RSpec.describe EventsController, type: :controller do
+  shared_examples_for 'authenticate' do
+    subject { response }
+    before  { session[:user_id] = nil }
+
+    context 'ログインしていないとき' do
+      it 'トップページにリダイレクトすること' do
+        expect(response).to redirect_to root_path
+      end
+    end
+  end
+
   before do
     @user = create(:user)
     session[:user_id] = @user.id
   end
 
   describe 'GET /events/new' do
-    before do
-      get :new
+    context 'ログインしているとき' do
+      before do
+        get :new
+      end
+
+      it 'ステータスコードが200であること' do
+        expect(response.status).to eq 200
+      end
+
+      it 'ビューとして new.html.erb が呼ばれること' do
+        expect(response).to render_template 'new'
+      end
+
+      it '@event にセッションのユーザIDと紐付く空イベントが格納されていること' do
+        expect(assigns(:event)).to be_a_new(Event)
+        expect(assigns(:event).owner_id).to eq @user.id
+      end
     end
 
-    it 'ユーザ認証が行われること' do
-      is_expected.to receive(:authenticate)
-      get :new
-    end
-
-    it 'ステータスコードが200であること' do
-      expect(response.status).to eq 200
-    end
-
-    it 'ビューとして new.html.erb が呼ばれること' do
-      expect(response).to render_template 'new'
-    end
-
-    it '@event にセッションのユーザIDと紐付く空イベントが格納されていること' do
-      expect(assigns(:event)).to be_a_new(Event)
-      expect(assigns(:event).owner_id).to eq @user.id
+    it_behaves_like 'authenticate' do
+      let(:response) { get :new }
     end
   end
 
   describe 'POST /events/' do
-    it 'ユーザ認証が行われること' do
-      is_expected.to receive(:authenticate)
-      post :new, attributes_for(:event)
-    end
+    context 'ログインしているとき' do
+      context '登録成功するとき' do
+        context 'フォームに全てのデータが入力されているとき' do
+          before do
+            @params = { event: attributes_for(:event) }
+            post :create, @params
+          end
 
-    context '登録成功するとき' do
-      context 'フォームに全てのデータが入力されているとき' do
-        before do
-          @params = { event: attributes_for(:event) }
-          post :create, @params
+          it '/event/:作成したイベントID にリダイレクトされること' do
+            expect(response).to redirect_to assigns(:event)
+          end
+
+          it 'フォーム送信されたデータと、DBに登録されたデータが一致すること' do
+            columns = @params[:event].keys
+            expect(assigns(:event).attributes.symbolize_keys.slice(*columns)).to eq @params[:event]
+          end
+
+          it 'flash[:notice] に「作成しました。」という文字列が格納されていること' do
+            expect(flash[:notice]).to eq '作成しました。'
+          end
         end
+      end
 
-        it '/event/:作成したイベントID にリダイレクトされること' do
-          expect(response).to redirect_to assigns(:event)
-        end
+      context '登録失敗するとき' do
+        context 'フォームに入力されたデータが空のとき' do
+          before do
+            @params = { event: attributes_for(:event, :with_blank) }
+            post :create, @params
+          end
 
-        it 'フォーム送信されたデータと、DBに登録されたデータが一致すること' do
-          columns = @params[:event].keys
-          expect(assigns(:event).attributes.symbolize_keys.slice(*columns)).to eq @params[:event]
-        end
+          it 'ステータスコードが200であること' do
+            expect(response.status).to eq 200
+          end
 
-        it 'flash[:notice] に「作成しました。」という文字列が格納されていること' do
-          expect(flash[:notice]).to eq '作成しました。'
+          it 'ビューとして new.html.erb が呼ばれること' do
+            expect(response).to render_template(:new)
+          end
+
+          it '@eventにエラー情報が格納されていること' do
+            expect(assigns(:event).errors.any?).to be_truthy
+          end
         end
       end
     end
 
-    context '登録失敗するとき' do
-      context 'フォームに入力されたデータが空のとき' do
-        before do
-          @params = { event: attributes_for(:event, :with_blank) }
-          post :create, @params
-        end
-
-        it 'ステータスコードが200であること' do
-          expect(response.status).to eq 200
-        end
-
-        it 'ビューとして new.html.erb が呼ばれること' do
-          expect(response).to render_template(:new)
-        end
-
-        it '@eventにエラー情報が格納されていること' do
-          expect(assigns(:event).errors.any?).to be_truthy
-        end
-      end
+    it_behaves_like 'authenticate' do
+      let(:response) { post :create }
     end
   end
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -1,17 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe EventsController, type: :controller do
-  shared_examples_for 'authenticate' do
-    subject { response }
-    before  { session[:user_id] = nil }
-
-    context 'ログインしていないとき' do
-      it 'トップページにリダイレクトすること' do
-        expect(response).to redirect_to root_path
-      end
-    end
-  end
-
   before do
     @user = create(:user)
     session[:user_id] = @user.id

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -11,6 +11,11 @@ RSpec.describe EventsController, type: :controller do
       get :new
     end
 
+    it 'ユーザ認証が行われること' do
+      is_expected.to receive(:authenticate)
+      get :new
+    end
+
     it 'ステータスコードが200であること' do
       expect(response.status).to eq 200
     end
@@ -26,6 +31,11 @@ RSpec.describe EventsController, type: :controller do
   end
 
   describe 'POST /events/' do
+    it 'ユーザ認証が行われること' do
+      is_expected.to receive(:authenticate)
+      post :new, attributes_for(:event)
+    end
+
     context '登録成功するとき' do
       context 'フォームに全てのデータが入力されているとき' do
         before do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -26,6 +26,7 @@ require 'shoulda-matchers'
 # require only the support files necessary.
 #
 # Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 # Checks for pending migration and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.

--- a/spec/support/login_helper.rb
+++ b/spec/support/login_helper.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+shared_examples_for 'authenticate' do
+  subject { response }
+  before  { session[:user_id] = nil }
+
+  context 'ログインしていないとき' do
+    it 'トップページにリダイレクトすること' do
+      expect(response).to redirect_to root_path
+    end
+  end
+end


### PR DESCRIPTION
### バグ内容

イベント新規作成画面ではユーザ認証が行われていない場合トップページに遷移させる挙動を想定していましたが、EventsControllerのbefore_actionにユーザ認証のメソッドを指定し忘れていたため、エラーが発生していました。

<img width="1036" alt="2016-06-09 11 39 30" src="https://cloud.githubusercontent.com/assets/10118235/15917361/e9475ce4-2e36-11e6-91a0-e5477fb67499.png">
### 修正内容

今回のバグを修正するため、以下を修正、実装しました。
- EventsControllerの各アクションでユーザ認証を行うメソッドが呼ばれることを確認するテストを記述
- EventsControllerのbefore_actionにauthenticateメソッドを指定
### 確認方法
- ログインしている場合、「イベントを作る」ボタンを押したらイベント新規作成画面に遷移すること
- ログアウトしている場合、「イベントを作る」ボタンを押したらトップページに遷移し「ログインしてください」と表示されること
