### PR TITLE
イベント詳細画面の実装

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -8,7 +8,7 @@ class EventsController < ApplicationController
     if Event.exists?(params[:id])
       @event = Event.find(params[:id])
     else
-      redirect_to Event
+      redirect_to Event, alert: 'ご指定のイベントは存在しません。'
     end
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,8 +1,15 @@
 class EventsController < ApplicationController
   before_action :authenticate
 
+  def index
+  end
+
   def show
-    @event = Event.find(params[:id])
+    if Event.exists?(params[:id])
+      @event = Event.find(params[:id])
+    else
+      redirect_to Event
+    end
   end
 
   def new

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,6 +2,7 @@ class EventsController < ApplicationController
   before_action :authenticate
 
   def show
+    @event = Event.find(params[:id])
   end
 
   def new

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,6 @@
 class Event < ActiveRecord::Base
+  belongs_to :owner, class_name: 'User'
+
   validates :name,       length: { maximum:   50 }, presence: true
   validates :place,      length: { maximum:  100 }, presence: true
   validates :content,    length: { maximum: 2000 }, presence: true

--- a/app/views/events/show.html.slim
+++ b/app/views/events/show.html.slim
@@ -1,1 +1,38 @@
+.page-header
+  h1
+    = @event.name
+    
+.panel.panel-default
+  .panel-heading
+    |
+      主催者
 
+  .panel-body
+    = link_to("http://twitter.com/#{@event.owner.nickname}") do
+      = image_tag @event.owner.image_url
+      = "@#{@event.owner.nickname}"
+
+.panel.panel-default
+  .panel-heading
+    |
+      開催時間
+
+  .panel-body
+    = @event.start_time.strftime('%Y%m%s %H:%M')+' - '+@event.end_time.strftime('%Y%m%s %H:%M')
+
+.panel.panel-default
+  .panel-heading
+    |
+      開催場所
+
+  .panel-body
+    = @event.place
+
+
+.panel.panel-default
+  .panel-heading
+    |
+      イベント内容
+
+  .panel-body
+    = @event.content

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -88,10 +88,14 @@ RSpec.describe EventsController, type: :controller do
       get :show, id: @event.id
     end
 
-    it 'ステータスコードが200であること'
+    it 'ステータスコードが200であること' do
+      expect(response.status).to eq 200
+    end
 
-    it 'ビューとして show.html.erb が呼ばれること'
-    
+    it 'ビューとして show.html.erb が呼ばれること' do
+      expect(response).to render_template 'show'
+    end
+
     it '@event にパラメータで渡したイベントIDと一致するインスタンスが格納されていること'
   end
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -83,21 +83,31 @@ RSpec.describe EventsController, type: :controller do
   end
 
   describe 'GET /events/:id' do
-    before do
-      @event = create(:event)
-      get :show, id: @event.id
+    context '存在するイベントIDが指定された場合' do
+      before do
+        @event = create(:event)
+        get :show, id: @event.id
+      end
+
+      it 'ステータスコードが200であること' do
+        expect(response.status).to eq 200
+      end
+
+      it 'ビューとして show.html.erb が呼ばれること' do
+        expect(response).to render_template 'show'
+      end
+
+      it '@event にパラメータで渡したイベントIDと一致するインスタンスが格納されていること' do
+        expect(assigns(:event).id).to eq @event.id
+      end
     end
 
-    it 'ステータスコードが200であること' do
-      expect(response.status).to eq 200
-    end
+    context '存在しないイベントIDが指定された場合' do
+      before { get :show, id: 0 }
 
-    it 'ビューとして show.html.erb が呼ばれること' do
-      expect(response).to render_template 'show'
-    end
-
-    it '@event にパラメータで渡したイベントIDと一致するインスタンスが格納されていること' do
-      expect(assigns(:event).id).to eq @event.id
+      it 'イベント一覧画面にリダイレクトされること' do
+        expect(response).to redirect_to action: 'index'
+      end
     end
   end
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -81,4 +81,17 @@ RSpec.describe EventsController, type: :controller do
       let(:response) { post :create }
     end
   end
+
+  describe 'GET /events/:id' do
+    before do
+      @event = create(:event)
+      get :show, id: @event.id
+    end
+
+    it 'ステータスコードが200であること'
+
+    it 'ビューとして show.html.erb が呼ばれること'
+    
+    it '@event にパラメータで渡したイベントIDと一致するインスタンスが格納されていること'
+  end
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -96,6 +96,8 @@ RSpec.describe EventsController, type: :controller do
       expect(response).to render_template 'show'
     end
 
-    it '@event にパラメータで渡したイベントIDと一致するインスタンスが格納されていること'
+    it '@event にパラメータで渡したイベントIDと一致するインスタンスが格納されていること' do
+      expect(assigns(:event).id).to eq @event.id
+    end
   end
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -108,6 +108,10 @@ RSpec.describe EventsController, type: :controller do
       it 'イベント一覧画面にリダイレクトされること' do
         expect(response).to redirect_to action: 'index'
       end
+
+      it 'flash[:alert] に「ご指定のイベントは存在しません。」という文字列が格納されていること' do
+        expect(flash[:alert]).to eq 'ご指定のイベントは存在しません。'
+      end
     end
   end
 end


### PR DESCRIPTION
### PRの目的

登録したイベントの情報を閲覧するための、イベント詳細画面の実装を行います。
### やったこと
- EventsController#showアクションのテストを記述
- Eventにbelongs_toリレーションを設定して、紐付いているユーザを簡単に取得できるよう実装
- showテンプレートにイベントの詳細が表示されるように実装
### 動作確認
- [x] イベント作成後に詳細画面に遷移し、登録したイベントの情報が閲覧できること
- [x] `/event/:id` にアクセスして、指定したIDを持つイベントの情報が閲覧できること
